### PR TITLE
Fix: remove old reference to ngModel into zh-multiselect

### DIFF
--- a/frontend/app/zh-forms/tabs/tab3/zh-form-tab3.component.html
+++ b/frontend/app/zh-forms/tabs/tab3/zh-form-tab3.component.html
@@ -207,7 +207,6 @@
             [values]="formMetaData.IMPACTS"
             [parentFormControl]="activityForm.controls.impacts"
             keyLabel="mnemonique"
-            [(ngModel)]="selectedItems"
             groupBy="category"
           />
           <small

--- a/frontend/app/zh-forms/tabs/tab6/zh-form-tab6.component.html
+++ b/frontend/app/zh-forms/tabs/tab6/zh-form-tab6.component.html
@@ -233,7 +233,6 @@
           <small>Statuts</small>
           <zh-multiselect
             [values]="formMetaData.PROTECTIONS"
-            [(ngModel)]="selectedItems"
             [parentFormControl]="formTab6.controls.protections"
             groupBy="category"
             keyLabel="mnemonique_status"

--- a/frontend/app/zh-forms/tabs/tab6/zh-form-tab6.component.ts
+++ b/frontend/app/zh-forms/tabs/tab6/zh-form-tab6.component.ts
@@ -60,7 +60,6 @@ export class ZhFormTab6Component implements OnInit {
   private $_currentZhSub: Subscription;
   private $_fromChangeSub: Subscription;
   private $_getTabChangeSub: Subscription;
-  public selectedItems = [];
   default_status: string = 'Indéterminé';
 
   readonly urbanColSize: string = '15%';


### PR DESCRIPTION
Ces références sont liées au changement vers zh-multiselect.
Elles devraient être inutiles maintenant.

--> Bien vérifier le comportement de ces deux menus déroulants
