### PR TITLE
Dynamic valid/invalid state of record button on tab0

### DIFF
--- a/frontend/app/zh-forms/map/map.component.ts
+++ b/frontend/app/zh-forms/map/map.component.ts
@@ -15,6 +15,7 @@ export class ZhFormMapComponent implements OnInit, AfterViewInit {
   @Output() draw = new EventEmitter<any>();
   @Output() edit = new EventEmitter<any>();
   @Output() endDraw = new EventEmitter<any>();
+  @Output() delete = new EventEmitter<any>();
 
   constructor(private _mapService: MapService) {}
 
@@ -38,8 +39,6 @@ export class ZhFormMapComponent implements OnInit, AfterViewInit {
         this._mapService.currentExtend.zoom
       );
     }
-    console.log(L.Draw);
-
     this._mapService.map.off(L.Draw.Event.DRAWSTART);
     this._mapService.map.on(L.Draw.Event.CREATED, (e) => {
       this.onDrawStop(e);
@@ -49,6 +48,9 @@ export class ZhFormMapComponent implements OnInit, AfterViewInit {
       this.onBeginEdit(e);
     });
     this._mapService.map.on(L.Draw.Event.EDITED, (e) => {
+      this.onEdit(e);
+    });
+    this._mapService.map.on(L.Draw.Event.DELETED, (e) => {
       this.onEdit(e);
     });
   }
@@ -67,5 +69,9 @@ export class ZhFormMapComponent implements OnInit, AfterViewInit {
 
   onDrawStop(e) {
     this.endDraw.emit(e);
+  }
+
+  onDeleted(e) {
+    this.delete.emit(e);
   }
 }

--- a/frontend/app/zh-forms/tabs/tab0/zh-form-tab0.component.html
+++ b/frontend/app/zh-forms/tabs/tab0/zh-form-tab0.component.html
@@ -5,6 +5,7 @@
         (draw)="updateGeom($event)"
         (endDraw)="onNewGeom($event)"
         (edit)="updateGeom($event)"
+        (delete)="updateGeom(null)"
       ></zh-form-map>
     </div>
     <div class="col-xl-6 col-lg-5 col-sm-6">
@@ -116,7 +117,7 @@
           mat-raised-button
           color="primary"
           class="ml-3"
-          [disabled]="posted"
+          [disabled]="posted || form.invalid || !isGeometryDefined"
           (click)="onFormSubmit(form.value)"
         >
           <mat-icon *ngIf="!posted">save_outline</mat-icon>

--- a/frontend/app/zh-forms/tabs/tab0/zh-form-tab0.component.ts
+++ b/frontend/app/zh-forms/tabs/tab0/zh-form-tab0.component.ts
@@ -13,6 +13,8 @@ import { PbfService } from '../../../services/pbf.service';
 
 const GEOM_CONTAINED_ID = 1;
 
+const EMPTY_GEOMETRY = { geojson: null };
+
 @Component({
   selector: 'zh-form-tab0',
   templateUrl: './zh-form-tab0.component.html',
@@ -31,7 +33,7 @@ export class ZhFormTab0Component implements OnInit {
   public idOrg: any;
   public $_geojsonSub: Subscription;
   public $_currentZhSub: Subscription;
-  private geometry: any;
+  private geometry: any = EMPTY_GEOMETRY;
   private currentLayer: any;
   public submitted = false;
   public posted = false;
@@ -81,6 +83,9 @@ export class ZhFormTab0Component implements OnInit {
         }
       });
     this._pbfService.setPaneBackground(this._mapService.map);
+  }
+  get isGeometryDefined(): boolean {
+    return this.geometry && this.geometry != EMPTY_GEOMETRY;
   }
 
   intiTab() {
@@ -254,6 +259,7 @@ export class ZhFormTab0Component implements OnInit {
   updateGeom(newGeometry: any) {
     this.canChangeTab.emit(false);
     this.geometry = newGeometry;
+    console.log(newGeometry);
   }
 
   onCancel() {


### PR DESCRIPTION
Sur la première page, le bouton de validation du formulaire n'est atteignable que lorsque le formulaire est en état valide (formulaire + map). 
J'ai testé un peu rapidement, mais ça m'a l'air OK.
A bien tester plusieurs configuration: création d'une ZH, modification, suppression, etc. 