### PR TITLE
fix: add optional chaining to search-dependant

### DIFF
--- a/frontend/app/zh-search/zh-search-items/components/zh-search-dependant/zh-search-dependant.component.ts
+++ b/frontend/app/zh-search/zh-search-items/components/zh-search-dependant/zh-search-dependant.component.ts
@@ -34,16 +34,14 @@ export class ZhSearchDependantComponent implements OnInit {
       this.enable();
       this._inputData = value;
     } else {
-      if (this.form) {
-        this.form.reset();
-      }
+      this.form?.reset();
       this.disable();
     }
   }
   disable() {
-    this.form.disable();
+    this.form?.disable();
   }
   enable() {
-    this.form.enable();
+    this.form?.enable();
   }
 }


### PR DESCRIPTION
Ajotu de la forme optional chaining sur l'usage du form, pour gérer les erreurs à l'initialisation